### PR TITLE
[Back-Add] user, post, hashtag model 추가

### DIFF
--- a/simplesns-backend/models/hashtag.js
+++ b/simplesns-backend/models/hashtag.js
@@ -24,5 +24,7 @@ module.exports = class Hashtag extends (
       }
     );
   }
-  static associate(db) {}
+  static associate(db) {
+    db.Hashtag.belongsToMany(db.Post, { through: "PostHashtag" });
+  }
 };

--- a/simplesns-backend/models/post.js
+++ b/simplesns-backend/models/post.js
@@ -28,5 +28,8 @@ module.exports = class Post extends (
     );
   }
 
-  static associate(db) {}
+  static associate(db) {
+    db.Post.belongsTo(db.User);
+    db.Post.belongsToMany(db.Hashtag, { through: "PostHashtag" });
+  }
 };

--- a/simplesns-backend/models/user.js
+++ b/simplesns-backend/models/user.js
@@ -43,5 +43,20 @@ module.exports = class User extends (
     );
   }
 
-  static associate(db) {}
+  static associate(db) {
+    //1:N = users: posts
+    db.User.hasMany(db.Post);
+    //N:M = following : follower
+    db.User.belongsToMany(db.User, {
+      foreignKey: "followingId",
+      as: "Followers",
+      through: "Follow",
+    });
+
+    db.User.belongsToMany(db.User, {
+      foreignKey: "followerId",
+      as: "Followings",
+      through: "Follow",
+    });
+  }
 };


### PR DESCRIPTION
- user와 post는 1대 다 관계
- follow 테이블을 통해 N:M관계의 팔로워 팔로잉
- PostHashtag를 통해 해시태그와 게시글 연결